### PR TITLE
Fix inference layout

### DIFF
--- a/app/textual_cli/moondream-cli.tcss
+++ b/app/textual_cli/moondream-cli.tcss
@@ -27,10 +27,30 @@ MoondreamCLI {
     align-vertical: bottom;
 }
 
+#main-layout {
+    height: 1fr;
+}
+
+#main_panel {
+    height: 1fr;
+}
+
+#infer_panel {
+    height: 1fr;
+}
+
+#infer_layout {
+    height: 1fr;
+}
+
 #response_container {
-    height: 10;
+    height: 1fr;
     overflow-y: auto;
     margin-bottom: 1;
+}
+
+#capibility_input_container {
+    dock: bottom;
 }
 
 .response-card {


### PR DESCRIPTION
## Summary
- extend inference layout to fill screen
- make input bar dock to bottom so the response list uses remaining height

## Testing
- `python -m py_compile app/textual_cli/moondream-cli.py`