### PR TITLE
Fix caption input bottom alignment

### DIFF
--- a/app/textual_cli/moondream-cli.tcss
+++ b/app/textual_cli/moondream-cli.tcss
@@ -28,9 +28,13 @@ MoondreamCLI {
 }
 
 #response_container {
-    height: 10;
+    height: 1fr;
     overflow-y: auto;
     margin-bottom: 1;
+}
+
+#capibility_input_container {
+    dock: bottom;
 }
 
 .response-card {


### PR DESCRIPTION
## Summary
- keep response container flexible so it fills space
- dock the caption input container to the bottom

## Testing
- `python -m py_compile app/textual_cli/moondream-cli.py`
- `pytest -q`