### PR TITLE
Graceful shutdown on exit

### DIFF
--- a/app/hypervisor/clivisor.py
+++ b/app/hypervisor/clivisor.py
@@ -25,6 +25,7 @@ class CLIVisor:
         self.config = config
         self.manifest = manifest
         self.base_dir = os.path.dirname(os.path.abspath(__file__))
+        self.cli_process = None
         logger.debug(f"clivisor initialized")
 
     def boot(self):
@@ -274,3 +275,18 @@ def install_moondream_cli(
             logger.error(f"⚠️  Could not update {rc}: {e}")
 
     return wrapper
+
+    def _kill_process(self):
+        """Terminate the running CLI subprocess if any."""
+        if self.cli_process is None:
+            return
+        try:
+            self.cli_process.terminate()
+            self.cli_process.wait(timeout=5)
+        except Exception:
+            self.cli_process.kill()
+        self.cli_process = None
+
+    def shutdown(self) -> None:
+        """Stop the CLI if it is running."""
+        self._kill_process()

--- a/app/hypervisor/hypervisor.py
+++ b/app/hypervisor/hypervisor.py
@@ -216,6 +216,8 @@ class Hypervisor:
             return
 
         print(f"Updating bootstrap to version {update_status['version']}...")
+        # Stop the CLI so update script can relaunch cleanly
+        self.clivisor.shutdown()
         with Spinner("Shutting down inference server..."):
             shutdown_result = self.inferencevisor.shutdown()
             logger.debug(f"Inference server shutdown result: {shutdown_result}")
@@ -300,6 +302,9 @@ class Hypervisor:
         """
         logger.info("Shutting down hypervisor and all components")
         print("Shutting down Moondream Station...")
+
+        # Stop the CLI first so the terminal is freed
+        self.clivisor.shutdown()
 
         with Spinner("Shutting down inference server..."):
             shutdown_result = self.inferencevisor.shutdown()

--- a/app/hypervisor/hypervisor_server.py
+++ b/app/hypervisor/hypervisor_server.py
@@ -420,6 +420,13 @@ async def shutdown_server(
     """Initiate a clean shutdown of the hypervisor server and all its components."""
     logger.info("Shutdown requested via API")
 
+    # Read optional exit code from request body
+    try:
+        payload = await request.json()
+    except Exception:
+        payload = {}
+    exit_code = int(payload.get("code", 0))
+
     # Start shutdown in a background task so we can return a response first
     async def shutdown_background():
         # Give time for the response to be sent
@@ -431,7 +438,7 @@ async def shutdown_server(
             if task is not asyncio.current_task():
                 task.cancel()
         # Signal to uvicorn to stop gracefully
-        os._exit(0)
+        os._exit(exit_code)
 
     # Schedule the background task
     asyncio.create_task(shutdown_background())

--- a/app/moondream_cli/commands/admin_commands.py
+++ b/app/moondream_cli/commands/admin_commands.py
@@ -2,6 +2,8 @@ import sys
 import time
 import requests
 import subprocess
+import os
+import shutil
 
 from typing import Dict, Any, Optional
 
@@ -329,10 +331,18 @@ class AdminCommands:
         else:
             print("No models available.")
 
-    def shutdown(self) -> None:
-        """Shutdown the hypervisor server."""
+    def shutdown(self, exit_code: int = 0) -> None:
+        """Shutdown the hypervisor server.
+
+        Parameters
+        ----------
+        exit_code: int, optional
+            Exit code for the hypervisor process. Non-zero prevents the
+            bootstrap from automatically restarting Moondream Station.
+        """
         print("Initiating server shutdown...")
-        result = self._make_request("POST", "/shutdown")
+        data = {"code": exit_code}
+        result = self._make_request("POST", "/shutdown", data)
 
         if result and result.get("status") == "ok":
             print(f"Shutdown initiated: {result.get('message', '')}")
@@ -387,18 +397,30 @@ class AdminCommands:
             else:
                 print("CLI update initiated successfully.")
 
-            # Exit after CLI update is complete on Ubuntu, as the CLI process needs to end
-            # so that the new CLI can be used on next invocation
             if check_platform() == "ubuntu":
-                print(
-                    "⚠️ CLI update complete. Please restart the CLI to use the updated version."
+                # Attempt to relaunch the updated CLI automatically
+                new_cli = shutil.which("moondream") or os.path.expanduser(
+                    "~/.local/bin/moondream"
                 )
-                sys.exit(0)
+                if new_cli and os.path.isfile(new_cli):
+                    print("Restarting CLI with updated version...")
+                    os.execv(new_cli, [new_cli] + sys.argv[1:])
+                else:
+                    print(
+                        "⚠️ CLI update complete. Please restart the CLI to use the updated version."
+                    )
+                    sys.exit(0)
 
         except requests.exceptions.ConnectionError:
             print("Update initiated. CLI is updating...")
             if check_platform() == "ubuntu":
-                sys.exit(0)
+                new_cli = shutil.which("moondream") or os.path.expanduser(
+                    "~/.local/bin/moondream"
+                )
+                if new_cli and os.path.isfile(new_cli):
+                    os.execv(new_cli, [new_cli] + sys.argv[1:])
+                else:
+                    sys.exit(0)
         except Exception as e:
             print(f"Error initiating CLI update: {e}")
 

--- a/app/moondream_cli/repl.py
+++ b/app/moondream_cli/repl.py
@@ -175,7 +175,10 @@ class MoondreamREPL:
                     print("Type 'help' for a list of available commands")
 
             except KeyboardInterrupt:
-                print("\nUse 'exit' or 'quit' to exit")
+                if self.cli.attached_station:
+                    self.exit([])
+                else:
+                    print("\nUse 'exit' or 'quit' to exit")
             except EOFError:
                 self.exit([])
             except Exception as e:
@@ -241,6 +244,13 @@ class MoondreamREPL:
     def exit(self, args: List[str] = None):
         """Exit the REPL."""
         print("Exiting Moondream CLI...")
+        if self.cli.attached_station:
+            # Request hypervisor shutdown with non-zero code so bootstrap
+            # does not restart automatically
+            try:
+                self.cli.admin_commands.shutdown(exit_code=1)
+            except Exception:
+                pass
         self.running = False
 
     def caption(self, args: List[str]):


### PR DESCRIPTION
## Summary
- allow CLI shutdown request to specify exit code and parse it in hypervisor server
- stop the CLI process when hypervisor shuts down or updates bootstrap
- exit the hypervisor when the CLI exits from the REPL

## Testing
- `python -m py_compile app/hypervisor/clivisor.py app/hypervisor/hypervisor.py app/hypervisor/hypervisor_server.py app/moondream_cli/commands/admin_commands.py app/textual_cli/commands/admin_commands.py app/moondream_cli/repl.py`
- `bash app/build.sh dev ubuntu` *(fails: cp cannot stat '../app/moondream_cli')*