### PR TITLE
Fix caption input bottom alignment

### DIFF
--- a/app/textual_cli/moondream-cli.tcss
+++ b/app/textual_cli/moondream-cli.tcss
@@ -27,8 +27,28 @@ MoondreamCLI {
     align-vertical: bottom;
 }
 
+# Layout rules so the caption input stays at the bottom while
+# the response area expands to fill remaining space.
+
+#main-layout {
+    height: 100%;
+}
+
+#main_panel {
+    height: 100%;
+    width: 1fr;
+}
+
+#infer_panel {
+    height: 100%;
+}
+
+#infer_layout {
+    height: 100%;
+}
+
 #response_container {
-    height: 10;
+    height: 1fr;
     overflow-y: auto;
     margin-bottom: 1;
 }


### PR DESCRIPTION
## Summary
- keep response container flexible so it fills space
- ensure all intermediary containers stretch to full height
- simplify layout so caption input remains at the bottom

## Testing
- `python -m py_compile app/textual_cli/moondream-cli.py`
- `pytest -q`
