### PR TITLE
Auto restart CLI after update

### DIFF
--- a/app/hypervisor/hypervisor.py
+++ b/app/hypervisor/hypervisor.py
@@ -216,6 +216,11 @@ class Hypervisor:
             return
 
         print(f"Updating bootstrap to version {update_status['version']}...")
+        # Stop the CLI so bootstrap can relaunch cleanly
+        try:
+            self.clivisor.shutdown()
+        except Exception as e:
+            logger.debug(f"Error shutting down CLI: {e}")
         with Spinner("Shutting down inference server..."):
             shutdown_result = self.inferencevisor.shutdown()
             logger.debug(f"Inference server shutdown result: {shutdown_result}")
@@ -300,6 +305,12 @@ class Hypervisor:
         """
         logger.info("Shutting down hypervisor and all components")
         print("Shutting down Moondream Station...")
+
+        # Stop the CLI first so the terminal is freed
+        try:
+            self.clivisor.shutdown()
+        except Exception as e:
+            logger.debug(f"Error shutting down CLI: {e}")
 
         with Spinner("Shutting down inference server..."):
             shutdown_result = self.inferencevisor.shutdown()

--- a/app/moondream_cli/commands/admin_commands.py
+++ b/app/moondream_cli/commands/admin_commands.py
@@ -2,6 +2,8 @@ import sys
 import time
 import requests
 import subprocess
+import os
+import shutil
 
 from typing import Dict, Any, Optional
 
@@ -387,18 +389,30 @@ class AdminCommands:
             else:
                 print("CLI update initiated successfully.")
 
-            # Exit after CLI update is complete on Ubuntu, as the CLI process needs to end
-            # so that the new CLI can be used on next invocation
             if check_platform() == "ubuntu":
-                print(
-                    "⚠️ CLI update complete. Please restart the CLI to use the updated version."
+                # Attempt to relaunch the updated CLI automatically
+                new_cli = shutil.which("moondream") or os.path.expanduser(
+                    "~/.local/bin/moondream"
                 )
-                sys.exit(0)
+                if new_cli and os.path.isfile(new_cli):
+                    print("Restarting CLI with updated version...")
+                    os.execv(new_cli, [new_cli] + sys.argv[1:])
+                else:
+                    print(
+                        "⚠️ CLI update complete. Please restart the CLI to use the updated version."
+                    )
+                    sys.exit(0)
 
         except requests.exceptions.ConnectionError:
             print("Update initiated. CLI is updating...")
             if check_platform() == "ubuntu":
-                sys.exit(0)
+                new_cli = shutil.which("moondream") or os.path.expanduser(
+                    "~/.local/bin/moondream"
+                )
+                if new_cli and os.path.isfile(new_cli):
+                    os.execv(new_cli, [new_cli] + sys.argv[1:])
+                else:
+                    sys.exit(0)
         except Exception as e:
             print(f"Error initiating CLI update: {e}")
 

--- a/app/moondream_cli/repl.py
+++ b/app/moondream_cli/repl.py
@@ -241,6 +241,11 @@ class MoondreamREPL:
     def exit(self, args: List[str] = None):
         """Exit the REPL."""
         print("Exiting Moondream CLI...")
+        if self.attached_station:
+            try:
+                self.cli.shutdown()
+            except Exception as e:
+                print(f"Error shutting down hypervisor: {e}")
         self.running = False
 
     def caption(self, args: List[str]):

--- a/app/textual_cli/commands/admin_commands.py
+++ b/app/textual_cli/commands/admin_commands.py
@@ -1,9 +1,11 @@
 import sys
 import time
 import requests
+import os
+import shutil
 from typing import Dict, Any, Optional
 
-from moondream_cli.utils.helpers import create_spinner, run_spinner
+from moondream_cli.utils.helpers import create_spinner, run_spinner, check_platform
 
 
 class AdminCommands:
@@ -348,8 +350,28 @@ class AdminCommands:
             else:
                 print("CLI update initiated successfully.")
 
+            if check_platform() == "ubuntu":
+                new_cli = shutil.which("moondream") or os.path.expanduser(
+                    "~/.local/bin/moondream"
+                )
+                if new_cli and os.path.isfile(new_cli):
+                    print("Restarting CLI with updated version...")
+                    os.execv(new_cli, [new_cli] + sys.argv[1:])
+                else:
+                    print(
+                        "⚠️ CLI update complete. Please restart the CLI to use the updated version."
+                    )
+
         except requests.exceptions.ConnectionError:
             print("Update initiated. CLI is updating...")
+            if check_platform() == "ubuntu":
+                new_cli = shutil.which("moondream") or os.path.expanduser(
+                    "~/.local/bin/moondream"
+                )
+                if new_cli and os.path.isfile(new_cli):
+                    os.execv(new_cli, [new_cli] + sys.argv[1:])
+                else:
+                    pass
         except Exception as e:
             print(f"Error initiating CLI update: {e}")
 


### PR DESCRIPTION
## Summary
- restart CLI automatically on Ubuntu after running update commands
- ensure CLI subprocess is terminated during hypervisor shutdown
- shutdown CLI before bootstrap update
- exiting REPL while attached triggers server shutdown

## Testing
- `python -m py_compile app/hypervisor/clivisor.py app/hypervisor/hypervisor.py app/moondream_cli/repl.py`
- `bash app/build.sh dev ubuntu`
