### PR TITLE
Update textual CLI layout

### DIFF
--- a/app/textual_cli/moondream-cli.py
+++ b/app/textual_cli/moondream-cli.py
@@ -83,14 +83,15 @@ class Infer(Static):
 
     def compose(self) -> ComposeResult:
         with Vertical(id="infer_layout"):
-            with Horizontal(id="capibility_horizontal_group"):
-                yield Button("Caption", id="caption_button", variant="primary")
-                yield Button("Query", id="query_button")
-                yield Button("Detect", id="detect_button")
-                yield Button("Point", id="point_button")
             with ScrollableContainer(id="response_container"):
                 yield LoadingIndicator(id="loading_indicator")
-            yield Container(id="capibility_input_container")
+            with Vertical(id="input_section"):
+                with Horizontal(id="capibility_horizontal_group"):
+                    yield Button("Caption", id="caption_button", variant="primary")
+                    yield Button("Query", id="query_button")
+                    yield Button("Detect", id="detect_button")
+                    yield Button("Point", id="point_button")
+                yield Container(id="capibility_input_container")
 
     def on_mount(self) -> None:
         """Mount the default input on start so layout positions correctly."""
@@ -225,8 +226,8 @@ class MoondreamCLI(App):
     def compose(self):
         yield Header()
 
-        with Horizontal(id="main-layout"):
-            with Vertical(id="sidebar"):
+        with Vertical(id="main-layout"):
+            with Horizontal(id="topbar"):
                 yield Button("💬 Infer", id="infer_button", variant="primary")
                 yield Button("🗄️  Logs", id="logs_button")
                 yield Button("⚙️  Setting", id="setting_button")

--- a/app/textual_cli/moondream-cli.tcss
+++ b/app/textual_cli/moondream-cli.tcss
@@ -3,24 +3,15 @@ MoondreamCLI {
     color: $text;
 }
 
-/* Sidebar styling */
-#sidebar {
-    width: 20;
-    height: 100%;
+/* Top navigation bar */
+#topbar {
+    width: 100%;
     background: $panel;
-    padding: 1 0;
+    padding: 1 1;
 }
 
-#infer_button {
-    width:100%;
-}
-
-#logs_button {
-    width:100%;
-}
-
-#setting_button {
-    width:100%;
+#topbar Button {
+    margin-right: 1;
 }
 
 .bottom {
@@ -28,7 +19,7 @@ MoondreamCLI {
 }
 
 #response_container {
-    height: 10;
+    height: 1fr;
     overflow-y: auto;
     margin-bottom: 1;
 }


### PR DESCRIPTION
## Summary
- refactor `MoondreamCLI` layout to use a top bar instead of sidebar
- move capability buttons above the input section in `Infer`
- update stylesheet for new top bar layout
- fix bottom input gap by making the response container fill remaining space

## Testing
- `python3 -m py_compile app/textual_cli/moondream-cli.py`
