### PR TITLE
Use uv to install dependencies instead of pip.

### DIFF
--- a/app/hypervisor/bootstrap.py
+++ b/app/hypervisor/bootstrap.py
@@ -313,6 +313,19 @@ def install_requirements(venv_dir: str, logger: logging.Logger):
     if res.stderr:
         logger.debug(f"Pip upgrade stderr:\n{res.stderr}")
 
+    logger.info("Installing uv package for fast Python package management...")
+    with Spinner("Installing uv..."):
+        res_uv = subprocess.run(
+            [python_bin, "-m", "pip", "install", "--upgrade", "uv"],
+            capture_output=True,
+            text=True,
+        )
+    logger.info(f"uv install return code: {res_uv.returncode}")
+    if res_uv.stdout:
+        logger.debug(f"uv install stdout:\n{res_uv.stdout}")
+    if res_uv.stderr:
+        logger.debug(f"uv install stderr:\n{res_uv.stderr}")
+
     if not os.path.isfile(requirements_file):
         logger.info(f"'{requirements_file}' not found, skipping requirements install.")
         return
@@ -320,7 +333,7 @@ def install_requirements(venv_dir: str, logger: logging.Logger):
     logger.info(f"Installing requirements from {requirements_file}")
     with Spinner("Installing Python requirements (this may take several minutes)..."):
         res = subprocess.run(
-            [python_bin, "-m", "pip", "install", "-U", "-r", requirements_file],
+            [python_bin, "-m", "uv", "pip", "install", "-U", "-r", requirements_file],
             capture_output=True,
             text=True,
         )

--- a/app/hypervisor/bootstrap.py
+++ b/app/hypervisor/bootstrap.py
@@ -291,6 +291,8 @@ def install_requirements(venv_dir: str, logger: logging.Logger):
     Raises:
         FileNotFoundError: If Python executable not found
     """
+    start_time = time.time()
+    logger.info("Installing Python requirements for hypervisor bootstrap...")
     requirements_file = "requirements.txt"
     python_bin = os.path.join(venv_dir, "bin", "python")
     logger.info(f"Using {python_bin} to install packages")
@@ -336,6 +338,11 @@ def install_requirements(venv_dir: str, logger: logging.Logger):
         logger.debug(f"Packages:\n{check_packages.stdout}")
     else:
         logger.debug(f"Error listing packages:\n{check_packages.stderr}")
+    end_time = time.time()
+    elapsed_time = end_time - start_time
+    logger.info(
+        f"Python requirements for hypervisor bootstrap installed in {elapsed_time:.2f} seconds"
+    )
 
 
 def _unset_sll_cert(signum: int, frame, logger: logging.Logger) -> None:

--- a/app/inference_client/bootstrap.py
+++ b/app/inference_client/bootstrap.py
@@ -250,6 +250,8 @@ def install_requirements(venv_dir: str, logger: logging.Logger):
     Raises:
         FileNotFoundError: If Python executable not found
     """
+    start_time = time.time()
+    logger.info("Installing requirements for inference client...")
     requirements_file = "requirements.txt"
     python_bin = os.path.join(venv_dir, "bin", "python")
     if not os.path.isfile(python_bin):
@@ -291,6 +293,9 @@ def install_requirements(venv_dir: str, logger: logging.Logger):
         logger.debug(f"Packages:\n{check_packages.stdout}")
     else:
         logger.debug(f"Error listing packages:\n{check_packages.stderr}")
+    end_time = time.time()
+    elapsed_time = end_time - start_time
+    logger.info(f"Requirements for inference client installed in {elapsed_time:.2f} seconds.")
 
 
 def _shutdown_proc(signum, _frame, proc: subprocess.Popen) -> None:


### PR DESCRIPTION
## What does this PR do?
This PR adds support for utilizing the [uv package manager](https://github.com/astral-sh/uv) instead of pip.

## Why this change?
Originally pip takes a long time to run an environment, which adds to wait time for the user when building moondream-station for the first time. Using uv is extremely fast and low hanging fruit to decrease this build time. 

## Tests
On our test environment we see a significant decrease in download and installation time for dependencies. 

Average rounded build times on my environment:

Tool | hypervisor | inference
-- | -- | --
pip | 5s | 50s
uv | 3s | 4s

[Hypervisor](https://github.com/EthanReid/moondream-station/blob/main/app/hypervisor/requirements.txt), [Inference](https://github.com/EthanReid/moondream-station/blob/main/app/inference_client/requirements.txt)

**Note: Although the installation times are environment dependent, test show it's always much faster to use uv instead of pip.**

**Test List**
- [x] Test on Ubuntu 20.04
- [x] Test on Ubuntu 22.04
- [x] Build on Ubuntu 20.04 and test on 22.04
