### PR TITLE
Support loading images from URLs in addition to local paths

### DIFF
--- a/app/moondream_cli/utils/image.py
+++ b/app/moondream_cli/utils/image.py
@@ -1,15 +1,16 @@
 from PIL import Image
 import os
-
+import requests
+from io import BytesIO
 
 def load_image(image_path: str) -> Image.Image:
-    """Load an image from a file path."""
-    if not os.path.exists(image_path):
-        print(f"Error: Image not found at path '{image_path}'")
-        raise FileNotFoundError(f"Image not found at {image_path}")
-
-    try:
-        return Image.open(image_path).convert("RGB")
-    except Exception as e:
-        print(f"Error loading image: {e}")
-        raise
+   """Load an image from a file path or URL."""
+   if image_path.startswith(('http://', 'https://')):
+       response = requests.get(image_path)
+       response.raise_for_status()
+       return Image.open(BytesIO(response.content)).convert("RGB")
+   
+   if not os.path.exists(image_path):
+       raise FileNotFoundError(f"Image not found at {image_path}")
+   
+   return Image.open(image_path).convert("RGB")


### PR DESCRIPTION
## What does this PR do?
This PR adds support for images on the web, so the user does not have to download images from the web and then query the image.

### Behavior
Now we can simply do:
``` bash
caption https://github.com/EthanReid/moondream-station/blob/main/assets/md_logo_clean.png?raw=true
```

## Tests:

- Tested with 50 random images on the internet
   - Different link endings
   - Different hosts
   - Different image formats (.jpg, .png, .gif)

Note : Random images were acquired by asking claude for 10 random words, then googling those words and randomly selecting 5 image links from google images. The reason this was done manually is because I wanted to simulate the user's PoV.