### PR TITLE
Refactor manifest structure and behavior

### DIFF
--- a/app/hypervisor/data/manifest.json
+++ b/app/hypervisor/data/manifest.json
@@ -3,38 +3,60 @@
     "manifest_date": "04/20/25",
     "current_bootstrap": {
         "version": "v0.0.1",
-        "url": "https://moondream-server-assets-dev.s3.us-west-2.amazonaws.com/moondream_station.tar.gz"
+        "url": "https://depot.moondream.ai/station/md_station_ubuntu.tar.gz"
     },
     "current_cli": {
         "version": "v0.0.1",
-        "url": "https://moondream-server-assets-dev.s3.us-west-2.amazonaws.com/moondream-cli.tar.gz"
+        "url": "https://depot.moondream.ai/station/md_station_cli_ubuntu.tar.gz "
     },
     "current_hypervisor": {
         "version": "v0.0.1",
-        "url": ""
+        "url": "https://depot.moondream.ai/station/md_station_hypervisor_ubuntu.tar.gz"
     },
     "models": {
-        "v2025.3.27": {
-            "revision": "2025-03-27",
-            "title": "Snow Moon 2025-03-27",
-            "release_date": "2025-03-27",
-            "notes": "Notes about what changed",
-            "model size": "1.93B",
-            "dtype": "fp16",
-            "is_cpu_only": false,
-            "support_osx": true,
-            "support_ubuntu": true,
-            "support_windows": false,
-            "inference_client": "v0.0.1"
+        "2b": {
+            "moondream-int4": {
+                "release_date": "None",
+                "revision_id": "2025-05-21",
+                "notes": "Our latest int4 model",
+                "model_size": "1.93B",
+                "dtype": "f16",
+                "support_osx": false,
+                "support_ubuntu": true,
+                "support_windows": false,
+                "inference_client": "v0.0.1"
+            },
+            "moondream-fp16": {
+                "release_date": "2025-04-14",
+                "revision_id": "2025-04-14",
+                "notes": "Our latest Float16 Moondream",
+                "model_size": "1.93B",
+                "dtype": "f16",
+                "support_osx": true,
+                "support_ubuntu": true,
+                "support_windows": false,
+                "inference_client": "v0.0.1"
+            },
+            "moondream-fp16-old": {
+                "release_date": "2025-03-27",
+                "revision_id": "2025-03-27",
+                "notes": "Our previous model",
+                "model_size": "1.93B",
+                "dtype": "fp16",
+                "support_osx": true,
+                "support_ubuntu": true,
+                "support_windows": false,
+                "inference_client": "v0.0.1"
+            }
         }
     },
     "inference_clients": {
         "v0.0.1": {
-            "date": "2025-03-27",
-            "url": "https://moondream-server-assets-dev.s3.us-west-2.amazonaws.com/inference.tar.gz"
+            "date": "2025-05-",
+            "url": "https://depot.moondream.ai/station/md_station_inference_bootstrap_ubuntu_int4.tar.gz"
         }
     },
     "notes": [
-        "Warning: this is a work in progress."
+        "Hello World, this is the Moondream Station manifest."
     ]
 }

--- a/app/hypervisor/data/manifest.json
+++ b/app/hypervisor/data/manifest.json
@@ -16,8 +16,9 @@
     "models": {
         "2b": {
             "moondream-int4": {
-                "release_date": "None",
-                "revision_id": "2025-05-21",
+                "release_date": "2025-05-21",
+                "model_id": "moondream/moondream-2b-2025-04-14-4bit",
+                "revision_id": "None",
                 "notes": "Our latest int4 model",
                 "model_size": "1.93B",
                 "dtype": "f16",
@@ -28,6 +29,7 @@
             },
             "moondream-fp16": {
                 "release_date": "2025-04-14",
+                "model_id":"vikhyatk/moondream2",
                 "revision_id": "2025-04-14",
                 "notes": "Our latest Float16 Moondream",
                 "model_size": "1.93B",
@@ -39,6 +41,7 @@
             },
             "moondream-fp16-old": {
                 "release_date": "2025-03-27",
+                "model_id":"vikhyatk/moondream2",
                 "revision_id": "2025-03-27",
                 "notes": "Our previous model",
                 "model_size": "1.93B",

--- a/app/hypervisor/data/manifest.json
+++ b/app/hypervisor/data/manifest.json
@@ -18,7 +18,7 @@
             "moondream-int4": {
                 "release_date": "2025-05-21",
                 "model_id": "moondream/moondream-2b-2025-04-14-4bit",
-                "revision_id": "None",
+                "revision": "None",
                 "notes": "Our latest int4 model",
                 "model_size": "1.93B",
                 "dtype": "f16",
@@ -30,7 +30,7 @@
             "moondream-fp16": {
                 "release_date": "2025-04-14",
                 "model_id":"vikhyatk/moondream2",
-                "revision_id": "2025-04-14",
+                "revision": "2025-04-14",
                 "notes": "Our latest Float16 Moondream",
                 "model_size": "1.93B",
                 "dtype": "f16",
@@ -42,7 +42,7 @@
             "moondream-fp16-old": {
                 "release_date": "2025-03-27",
                 "model_id":"vikhyatk/moondream2",
-                "revision_id": "2025-03-27",
+                "revision": "2025-03-27",
                 "notes": "Our previous model",
                 "model_size": "1.93B",
                 "dtype": "fp16",

--- a/app/hypervisor/inferencevisor.py
+++ b/app/hypervisor/inferencevisor.py
@@ -95,12 +95,12 @@ class InferenceVisor:
                 if model_data and model_data["model"]:
                     model_info = model_data["model"]
                     model_id = model_info.get("model_id")
-                    revision_id = model_info.get("revision_id")
+                    revision = model_info.get("revision")
                     
                     if model_id:
                         cmd.extend(["--model-id", model_id])
-                    if revision_id and revision_id != "None":
-                        cmd.extend(["--revision", revision_id])
+                    if revision and revision != "None":
+                        cmd.extend(["--revision", revision])
                         
             with Spinner(f"Loading Model {self.config.active_model}..."):
                 self.process = subprocess.Popen(
@@ -414,9 +414,9 @@ class InferenceVisor:
 
         ret_value = {
             "ood": False,
-            "revision": self.manifest.latest_model["revision"],
+            "revision": self.manifest.latest_model["model"]["revision"],
         }
-        if self.config.active_model != self.manifest.latest_model["revision"]:
+        if self.config.active_model != self.manifest.latest_model["model_name"]:
             ret_value["ood"] = True
         return ret_value
 

--- a/app/hypervisor/manifest.py
+++ b/app/hypervisor/manifest.py
@@ -30,10 +30,15 @@ class Manifest:
             self._load_local()
 
     def update(self):
-        self.logger.debug(f"Downloading manifest from {self.url} to {self.path}")
-        self._download()
-        self.logger.debug(f"Loading manifest from {self.path}")
-        self._load_local()
+        if self.url.startswith(('http://', 'https://')):
+            self.logger.debug(f"Downloading manifest from {self.url} to {self.path}")
+            self._download()
+            self.logger.debug(f"Loading manifest from {self.path}")
+            self._load_local()
+        else:
+            self.logger.debug(f"Loading manifest directly from local path {self.url}")
+            self.path = self.url
+            self._load_local()
 
     def _load_local(self) -> Dict[str, Any]:
         try:
@@ -45,7 +50,6 @@ class Manifest:
     def _download(self):
         try:
             os.makedirs(os.path.dirname(self.path), exist_ok=True)
-
             download_file(self.url, self.path, self.logger)
         except Exception as e:
             self.logger.error(f"Error downloading manifest: {e}")

--- a/app/hypervisor/manifest.py
+++ b/app/hypervisor/manifest.py
@@ -102,32 +102,39 @@ class Manifest:
         if not models_dict:
             return None
         
-        revision_ids = [model_data.get("revision_id") for model_data in models_dict.values() if model_data.get("revision_id")]
-        if not revision_ids:
+        release_dates = [model_data.get("release_date") for model_data in models_dict.values() if model_data.get("release_date")]
+        if not release_dates:
             return None
         
         grouped = {}
-        for rev in revision_ids:
-            numeric = parse_revision(rev)
-            grouped.setdefault(numeric, []).append(rev)
+        for date in release_dates:
+            numeric = parse_revision(date)
+            grouped.setdefault(numeric, []).append(date)
         
         latest_numeric = max(grouped.keys())
         candidates = grouped[latest_numeric]
         
         chosen = None
-        for rev in candidates:
-            if "4bit" in rev:
-                chosen = rev
+        for date in candidates:
+            if "4bit" in date:
+                chosen = date
                 break
         if not chosen:
-            for rev in candidates:
-                if all(c.isdigit() or c == "-" for c in rev):
-                    chosen = rev
+            for date in candidates:
+                if all(c.isdigit() or c == "-" for c in date):
+                    chosen = date
                     break
         if not chosen:
             chosen = candidates[0]
         
-        return self.get_model(chosen)
+        for model_name, model_data in models_dict.items():
+            if model_data.get("release_date") == chosen:
+                return {
+                    "revision": model_data.get("revision_id"),
+                    "model": model_data,
+                }
+        
+        return None
 
     def get_inference_client(self, version: str) -> Optional[Dict[str, str]]:
         return self.data.get("inference_clients", {}).get(version, None)

--- a/app/hypervisor/manifest.py
+++ b/app/hypervisor/manifest.py
@@ -4,7 +4,7 @@ import logging
 
 from typing import Dict, Any, Optional, List
 
-from misc import parse_version, parse_revision, download_file, check_platform
+from misc import parse_version, parse_date, download_file, check_platform
 
 PLATFORM = check_platform()
 MANIFEST_URL = "https://depot.moondream.ai/station/md_station_manifest_ubuntu.json"
@@ -108,7 +108,7 @@ class Manifest:
         
         grouped = {}
         for date in release_dates:
-            numeric = parse_revision(date)
+            numeric = parse_date(date)
             grouped.setdefault(numeric, []).append(date)
         
         latest_numeric = max(grouped.keys())

--- a/app/hypervisor/manifest.py
+++ b/app/hypervisor/manifest.py
@@ -81,11 +81,16 @@ class Manifest:
     def current_cli(self) -> Dict[str, str]:
         return self.data.get("current_cli", {})
 
+    
     def get_model(self, revision: str) -> Optional[Dict[str, Any]]:
-        return {
-            "revision": revision,
-            "model": self.models.get(revision, None),
-        }
+        models_dict = self.data.get("models", {}).get(MODEL_SIZE, {})
+        for model_name, model_data in models_dict.items():
+            if model_data.get("revision_id") == revision:
+                return {
+                    "revision": revision,
+                    "model": model_data,
+                }
+        return None
 
     @property
     def models(self) -> Dict[str, Dict[str, Any]]:
@@ -96,19 +101,19 @@ class Manifest:
         models_dict = self.models
         if not models_dict:
             return None
-        # Group revisions by their numeric components
+        
+        revision_ids = [model_data.get("revision_id") for model_data in models_dict.values() if model_data.get("revision_id")]
+        if not revision_ids:
+            return None
+        
         grouped = {}
-        for rev in models_dict.keys():
+        for rev in revision_ids:
             numeric = parse_revision(rev)
             grouped.setdefault(numeric, []).append(rev)
-
-        # Determine the numerically latest revision
+        
         latest_numeric = max(grouped.keys())
         candidates = grouped[latest_numeric]
-
-        # Prefer a revision containing "4bit" when multiple revisions share the
-        # same numeric value. Otherwise favour the revision without alphabetic
-        # characters.
+        
         chosen = None
         for rev in candidates:
             if "4bit" in rev:
@@ -121,7 +126,7 @@ class Manifest:
                     break
         if not chosen:
             chosen = candidates[0]
-
+        
         return self.get_model(chosen)
 
     def get_inference_client(self, version: str) -> Optional[Dict[str, str]]:

--- a/app/hypervisor/manifest.py
+++ b/app/hypervisor/manifest.py
@@ -82,14 +82,13 @@ class Manifest:
         return self.data.get("current_cli", {})
 
     
-    def get_model(self, revision: str) -> Optional[Dict[str, Any]]:
+    def get_model(self, model_name: str) -> Optional[Dict[str, Any]]:
         models_dict = self.data.get("models", {}).get(MODEL_SIZE, {})
-        for model_name, model_data in models_dict.items():
-            if model_data.get("revision_id") == revision:
-                return {
-                    "revision": revision,
-                    "model": model_data,
-                }
+        if model_name in models_dict:
+            return {
+                "model_name": model_name,
+                "model": models_dict[model_name],
+            }
         return None
 
     @property
@@ -130,7 +129,7 @@ class Manifest:
         for model_name, model_data in models_dict.items():
             if model_data.get("release_date") == chosen:
                 return {
-                    "revision": model_data.get("revision_id"),
+                    "model_name": model_name,
                     "model": model_data,
                 }
         

--- a/app/hypervisor/misc.py
+++ b/app/hypervisor/misc.py
@@ -14,10 +14,10 @@ def parse_version(version: str) -> tuple[int, ...]:
     return tuple(int(part) for part in version.split("."))
 
 
-def parse_revision(revision: str) -> tuple[int, ...]:
+def parse_date(date: str) -> tuple[int, ...]:
     """Extract integer components from a revision string.
 
-    This helper gracefully handles revisions that contain alphabetic
+    This helper gracefully handles dates that contain alphabetic
     prefixes/suffixes such as ``2025-04-14-4bit`` or ``4bit-2025-04-14``.
     Any numeric sequences found in the string are returned as a tuple of
     integers.  If no digits are found, ``(0,)`` is returned so that the
@@ -25,7 +25,7 @@ def parse_revision(revision: str) -> tuple[int, ...]:
     """
     import re
 
-    numeric_parts = re.findall(r"\d+", revision)
+    numeric_parts = re.findall(r"\d+", date)
     if not numeric_parts:
         return (0,)
     return tuple(int(part) for part in numeric_parts)

--- a/app/inference_client/main.py
+++ b/app/inference_client/main.py
@@ -25,7 +25,7 @@ VERSION = "v0.0.2"
 
 
 async def lifespan(app: FastAPI):
-    model_name = "vikhyatk/moondream2"
+    model_name = getattr(app.state, "model_id", "vikhyatk/moondream2")
     revision = getattr(app.state, "revision", None)
     app.state.model_service = ModelService(model_name, revision)
     logger.info("Model initialized successfully.")
@@ -332,9 +332,14 @@ if __name__ == "__main__":
     parser.add_argument(
         "--revision", type=str, default=None, help="Moondream revision to use"
     )
+    parser.add_argument(
+        "--model-id", type=str, default=None, help="Moondream model ID to use"
+    )
     args = parser.parse_args()
-
+    
     app.state.revision = args.revision
 
+    if args.model_id:
+        app.state.model_id = args.model_id
     logger.info(f"Starting server on port: {args.port}")
     uvicorn.run(app, host="0.0.0.0", port=args.port, log_level="error")


### PR DESCRIPTION
## Before this PR:

- Models were identified by revision IDs than a model_name. 
  - Since INT4 did not have the same revision ID, this caused problems where we needed separate logic.
- Only revision ID was passed to the inference server, model_id was hard-coded.
- The revision ID was being used as the source for setting the latest model.

## What does this PR do?
- Models can now have descriptive names which serve as unique identifiers. For example, "moondream-int4" or "moondream-fp16" or anything we want. To load a specific model using `admin model-load`, we can now use those model names.
- Revision ID is now a field in the model data. Revision can now be None, for example in the INT4 model.
- We find the latest model available from the release date field and not the revision field.
- Model ID is now not hardcoded. We pass the model id from the manifest to the inference server.
- Fixed an issue where if the manifest file had a local path, we would still try to download it. Now we don't try to download the manifest if it's a local path.

## Why this change?
- Allows us to not be hacky with creating our tarfiles.
- Allows the INT4 model to not have a different logical path because of revision.

## Tests
### Capability Tests (per model available)
- [ ] Caption
- [ ] Query
- [ ] Point
- [ ] Detect
### Admin Commands
- [ ] Switch models back and forth
- [ ] Print available models
