### PR TITLE
Fix : Don't download manifest if MANIFEST_URL is a local path

### DIFF
--- a/app/hypervisor/manifest.py
+++ b/app/hypervisor/manifest.py
@@ -30,10 +30,15 @@ class Manifest:
             self._load_local()
 
     def update(self):
-        self.logger.debug(f"Downloading manifest from {self.url} to {self.path}")
-        self._download()
-        self.logger.debug(f"Loading manifest from {self.path}")
-        self._load_local()
+        if self.url.startswith(('http://', 'https://')):
+            self.logger.debug(f"Downloading manifest from {self.url} to {self.path}")
+            self._download()
+            self.logger.debug(f"Loading manifest from {self.path}")
+            self._load_local()
+        else:
+            self.logger.debug(f"Loading manifest directly from local path {self.url}")
+            self.path = self.url
+            self._load_local()
 
     def _load_local(self) -> Dict[str, Any]:
         try:


### PR DESCRIPTION
## What does this PR do?
Fixed an issue where if the manifest file had a local path, we would still try to download it. Now we don't try to download the manifest if it's a local path.

## Tests
Tested along with #33 on the same tests but pushed as a separate PR here.