### PR TITLE
Add an option to run using build.sh

### DIFF
--- a/app/build.sh
+++ b/app/build.sh
@@ -215,7 +215,7 @@ case "$TYPE" in
     dev)         prepare_dev       ;;
     run)         run_station       ;;
     *)
-        echo "Usage: $0 <inference|hypervisor|cli|dev|run> [platform]" >&2
+        echo "Usage: $0 {inference|hypervisor|cli|dev} [platform] | $0 run" >&2
         exit 1
         ;;
 esac


### PR DESCRIPTION
## What does this PR do?
Adds capability to run the ./moondream_station executable created from the bashfile itself.

## Why do we need this PR?
Previously to build and run moondream station our workflow was:
```bash
cd app
bash build.sh dev ubuntu --build-clean
cd ..
./output/moondream_station/moondream_station
```
It can now be condensed to:
```bash
cd app
bash build.sh dev ubuntu --build-clean && bash build.sh run
```
(With the option to run `bash build.sh run` separately!)
Automating this saves a lot of devtime accumulated over multiple runs/tests since we don't exit the app directory.

## Tests

- [x] Tested on Ubuntu 22.04