### PR TITLE
Fix null update

### DIFF
--- a/app/moondream_cli/commands/admin_commands.py
+++ b/app/moondream_cli/commands/admin_commands.py
@@ -355,9 +355,13 @@ class AdminCommands:
                 if key in result:
                     status = result[key]
                     model_name = status.get("model_name", "Unknown")
+                    version = status.get("version", None) or status.get("revision", "")
                     needs_update = status.get("ood", False)
                     update_status = "Update available" if needs_update else "Up to date"
-                    print(f"{name}: {model_name} - {update_status}")
+                    if key !="model":
+                        print(f"{name}: {version} - {update_status}")
+                    else:
+                        print(f"{name}: {model_name} - {update_status}")
                 else:
                     print(f"{name}: Status unknown")
 


### PR DESCRIPTION
In #33 we switched from `version` to `model_name` - [change here](https://github.com/EthanReid/moondream-station/pull/33/files#r2157696145). This causes a unintended behavior that it will display version as Unknown for the rest of the components (Hypervisor, Bootstrap, CLI). We reverse this change by adding a conditional statement which checks if the component is `model` or one of `hypervisor`, `bootstrap` or `cli`.

Tested on Ubuntu 20.04
