### PR TITLE
Fix: CLI taking on Hypervisor Update

### DIFF
--- a/app/hypervisor/clivisor.py
+++ b/app/hypervisor/clivisor.py
@@ -111,7 +111,7 @@ class CLIVisor:
 
         ret_value = {
             "ood": False,
-            "version": self.manifest.current_hypervisor["version"],
+            "version": self.manifest.current_cli["version"],
         }
         if self.config.active_cli != self.manifest.current_cli["version"]:
             ret_value["ood"] = True


### PR DESCRIPTION
## What does this PR do?
This PR fixes the behavior of check_for_update where we returned hypervisor's version instead of the actual CLI's version when we update.

```py
    def check_for_update(self, update_manifest: bool = True) -> dict:
        """
        Check if a CLI update is available.

        Args:
            update_manifest: If True, refresh manifest data before checking

        Returns:
            dict: Status containing "ood" (out of date) flag and current version
        """
        if update_manifest:
            self.manifest.update()

        ret_value = {
            "ood": False,
            "version": self.manifest.current_cli["version"], # <- Here. This was earlier "current_hypervisor"!
        }
        if self.config.active_cli != self.manifest.current_cli["version"]:
            ret_value["ood"] = True
        return ret_value
```

## Tests
- Tested on Ubuntu 22.04 (3090 and 4050)